### PR TITLE
Added point light glow fade for lights that are too close to the camera

### DIFF
--- a/shaders/clouds.omwfx
+++ b/shaders/clouds.omwfx
@@ -96,7 +96,7 @@ uniform_float point_glow_strength {
 }
 
 uniform_float point_glow_min_fade_dist {
-    default = 30.0;
+    default = 50.0;
     min = 0.0;
     max = 1024.0;
     step = 1.0;
@@ -112,7 +112,7 @@ uniform_float point_glow_max_fade_dist {
 }
 
 uniform_float point_glow_fade {
-    default = 0.2;
+    default = 0.0;
     min = 0.0;
     max = 1.0;
     step = 0.05;

--- a/shaders/clouds.omwfx
+++ b/shaders/clouds.omwfx
@@ -95,6 +95,30 @@ uniform_float point_glow_strength {
     description = "Strength of glow around point lights";
 }
 
+uniform_float point_glow_min_fade_dist {
+    default = 30.0;
+    min = 0.0;
+    max = 1024.0;
+    step = 1.0;
+    description = "Minimum distance from the camera that the point light glow starts to fade in";
+}
+
+uniform_float point_glow_max_fade_dist {
+    default = 100.0;
+    min = 0.0;
+    max = 1024.0;
+    step = 1.0;
+    description = "Distance from the camera that the point light glow fully fades in";
+}
+
+uniform_float point_glow_fade {
+    default = 0.2;
+    min = 0.0;
+    max = 1.0;
+    step = 0.05;
+    description = "How much point lights fade out when they are too close. Use this to fade out torches/lamps that the player is holding.";
+}
+
 uniform_bool point_glow_diffusion {
     default = true;
     description = "Whether mist and clouds should influence point glow (may be expensive)";
@@ -318,6 +342,11 @@ fragment main {
         float d2 = rpos.x * rpos.x + rpos.y * rpos.y + rpos.z * rpos.z;
         return 1.0 / (100.0 + d2);
     }
+	
+	// Maps a float from an input range to an output range, without clamping
+	float map(float value, float min1, float max1, float min2, float max2) {
+	  return min2 + (value - min1) * (max2 - min2) / (max1 - min1);
+	}
 
     vec3 apply_point_glow(vec3 wpos, vec3 dir, float max_dist, vec3 color) {
         for (int i = 0; i < omw_GetPointLightCount(); i ++) {
@@ -338,6 +367,14 @@ fragment main {
                 * 0.5
                 * point_glow_strength
                 * max(1.0 - t * 0.0002, 0.0);
+			
+			// Fade out point lights that are too close to the camera
+			{
+				float d2 = distance(omw.eyePos.xyz, light_pos);
+				d2 = map(d2, point_glow_min_fade_dist, point_glow_max_fade_dist, point_glow_fade, 1.0);
+				d2 = clamp(d2, point_glow_fade, 1.0);
+				strength *= d2;
+			}
 
             if (clamp_point_glow) {
                 strength *= max(0.0, 1.0 - distance_2 / pow(omw_GetPointLightRadius(i), 2.0));


### PR DESCRIPTION
Adds a point light glow fade for lights that are too close to the camera. This is to make torches/lamps/etc that the player is carrying not blow out the entire screen with their glow.

The PR adds 3 settings: point_glow_min_fade_dist, point_glow_max_fade_dist, point_glow_fade.
- point_glow_min_fade_dist: the distance from the camera that lights start to fade in. The strength of lights closer than this  distance is multiplied by point_glow_fade.
- point_glow_max_fade_dist: any light farther than this does not have its glow altered
- point_glow_fade: the maximum amount that point lights will be faded out. So if this is set at 0.2, lights closer than point_glow_min_fade_dist will be multiplied by 0.2

### Comparison shots:
![screenshot004](https://user-images.githubusercontent.com/8600772/172486667-9b844847-d880-411d-b516-fd5301bb7d1b.png)
point_glow_fade on with default settings


![screenshot005](https://user-images.githubusercontent.com/8600772/172486707-1d0fecb9-1b26-425b-89cb-ef4bc1fd7e55.png)
no point_glow_fade
