### PR TITLE
Fix typos introduced by 818da0aa

### DIFF
--- a/shaders/clouds.omwfx
+++ b/shaders/clouds.omwfx
@@ -355,7 +355,7 @@ fragment main {
         int z = int(floor(pos.z));
         vec2 offs0 = vec2(hash_one(z), hash_one(z + 73));
         vec2 offs1 = vec2(hash_one(z + 1), hash_one(z + 1 + 73));
-        retrn mix(
+        return mix(
             billow_noise_2d(pos.xy + offs0),
             billow_noise_2d(pos.xy + offs1),
             fract(pos.z)
@@ -363,15 +363,15 @@ fragment main {
     }
 
     const float MIN_MIST_DIST = 100.0;
-    const float MIN_CLOD_DIST = 10000.0;
+    const float MIN_CLOUD_DIST = 10000.0;
 
-    vec2 fog_at(vec3 wpos, float cll_dist, vec3 dir, in float dyn_clods, in float dyn_mist) {
+    vec2 fog_at(vec3 wpos, float cull_dist, vec3 dir, in float dyn_clouds, in float dyn_mist) {
         wpos.z = max(wpos.z, 0);
-        vec3 time = vec3(omw.simlationTime * 0.1, 0, 0);
+        vec3 time = vec3(omw.simulationTime * 0.1, 0, 0);
 
         float mist = 0.0;
 
-        if (mist_enabled && cll_dist > MIN_MIST_DIST) {
+        if (mist_enabled && cull_dist > MIN_MIST_DIST) {
             float mist_base = omw.waterHeight
                 + mist_alt
                 + (noise_2d(wpos.xy * 0.000003 + time.xy * 0.03) - 0.6) * 3000;


### PR DESCRIPTION
Fixes the typos accidentally introduced with 818da0aa434b50809f30764955b3f2ddf886d04a as discussed in #32 