### PR TITLE
Dehardcoding scattering

### DIFF
--- a/shaders/clouds.omwfx
+++ b/shaders/clouds.omwfx
@@ -472,6 +472,7 @@ fragment main {
     vec3 sun_dir = normalize(omw.sunPos.xyz);
 
     vec3 sun_color = vec3(omw.sunColor);
+    // vec3 sun_color = vec3(int(sun.dir.z + 1), int(sun.dir.z + 1), int(sun.dir.z + 1));
 
 	vec3 weather_tone[10]=vec3[](
 		vec3(0.85),  //Clear
@@ -504,11 +505,11 @@ fragment main {
         //Define the atmospheric attenuation factors for sunlight's red, green, and blue channels
         vec3 att_factor = vec3(
             (pow((2 / (abs(sun_dir.z) + 1)), 2) / 2),
-            (sqrt(1 / (abs(sun_dir.z) + 1)) / 2),
-            pow((1 / (abs(sun_dir.z) + 1)), 2)
+            (sqrt(1 / (abs(sun_dir.z))) / 10 * (abs(sun_dir.z))),
+            (pow((1 / (abs(sun_dir.z) + 1)), 2) * 3 * (-1 * (abs(sun_dir.z))))
         );
         //Interpolate between original sun color and attenuated color based on sun's proximity to the horizon
-        vec3 sun_attenuated = vec3(mix(vec3(min((sun_color.x * ((dot(dir, sun_dir) + 1) / 2) * att_factor.x), 255), min((sun_color.y * (dot(dir, sun_dir) + 1) * att_factor.y), 255), min((sun_color.z / ((dot(dir, sun_dir) + 1) * att_factor.z)),255)), sun_color, abs(sun_dir.z)));
+        vec3 sun_attenuated = vec3(mix(vec3(min((sun_color.x * ((dot(dir, sun_dir) + 1) / 2) * att_factor.x), 255), min((sun_color.y * (dot(dir, sun_dir) + 1) * att_factor.y), 255), min((sun_color.z / (dot(dir, sun_dir) + 2) * att_factor.z),255)), sun_color, abs(sun_dir.z)));
         //Have fog color be directionally influenced by sunlight
         vec3 fog_color = mix(
             vec3(omw.fogColor), 
@@ -566,7 +567,7 @@ fragment main {
 
             // Rayleigh scattering
             vec3 ambient = vec3(omw.ambientColor);
-            col.rgb = mix(col.rgb, (mix(mix(sky_color,(mix(mix(sky_color, mix(vec3(max(sun_attenuated.x, sky_color.x), max(sun_attenuated.y, sky_color.y), max(sun_attenuated.z, sky_color.z)), mix(max(ambient, sky_color), fog_color, normalize(pow((dot(sun_dir, dir) + 1), 2))), normalize(pow((dot(sun_dir, dir) + 1), 4))), (dot(dir, sun_dir) + 1)), sun_attenuated + sky_color, (sqrt(max(dot(dir, sun_dir), 0.0001)) / 2))), (dot(dir, sun_dir), + 1)), max(max(sky_color, ambient), fog_color), abs(sun_dir.z))), (1.0 - 1.0 / (1.0 + step * 0.00001 * scattering_factor * (2 + (pow((dot(dir, sun_dir), + 1), 2) )* 5))) * clamp((15000 - spos.z) * 0.0001, 0.0, 1.0));
+            col.rgb = mix(col.rgb, (mix(mix(sky_color,(mix(mix(sky_color, mix(vec3(max(sun_attenuated.x, sky_color.x), max(sun_attenuated.y, sky_color.y), max(sun_attenuated.z, sky_color.z)), mix(max(ambient, sky_color), fog_color, normalize(pow((dot(sun_dir, dir) + 1), 2))), normalize(pow((dot(sun_dir, dir) + 1), 4))), (dot(dir, sun_dir) + 1)), sun_attenuated + sky_color, (sqrt(max(((dot(dir, sun_dir) + 1)/ 2), 1))) )), (dot(dir, sun_dir), + 1)), max(max(sky_color, ambient), fog_color), abs(sun_dir.z))), (1.0 - 1.0 / (1.0 + step * 0.00001 * scattering_factor * (2 + max((pow((dot(dir, sun_dir), + 1), 2)), 1)* 5))) * clamp((15000 - spos.z) * 0.0001, 0.0, 1.0));
 
             dist = new_dist;
             f -= 1;

--- a/shaders/clouds.omwfx
+++ b/shaders/clouds.omwfx
@@ -122,7 +122,7 @@ uniform_float mist_density {
 uniform_float mist_alt {
     default = 1500.0;
     min = 0.0;
-    max = 3000.0;
+    max = 5000.0;
     step = 250;
     display_name = "Altitude";
     description = "Average altitude of mist above the water level";
@@ -327,7 +327,7 @@ fragment main {
     // Replace this function with the one below it if your GPU can't handle bitwise ops
     float hash_one(int q) {
         int n = ((M3 * q) ^ M2) * M1;
-        return float(n) * (1.0 / float(0xffffffff));
+        return float(n) * (1.0 / float(0xffffffffu));
     }
 
     float noise_2d(vec2 pos) {
@@ -471,11 +471,7 @@ fragment main {
 
     vec3 sun_dir = normalize(omw.sunPos.xyz);
 
-    vec3 sun_color = mix(
-        vec3(2, 0.5, 0.2) * 3,
-        vec3(0.6, 0.5, 0.0),
-        pow(max(sun_dir.z + 0.2, 0.001), 0.1)
-    );
+    vec3 sun_color = vec3(omw.sunColor);
 
 	vec3 weather_tone[10]=vec3[](
 		vec3(0.85),  //Clear
@@ -492,15 +488,7 @@ fragment main {
 
     vec3 sky_tone = mix(weather_tone[omw.weatherID], weather_tone[omw.nextWeatherID], omw.weatherTransition);
 
-    vec3 sky_color = mix(
-        mix(
-            vec3(1.2, 0.4, 0.2),
-            vec3(0.01, 0.05, 0.1),
-            pow(max(-sun_dir.z + 0.2, 0.001), 0.2)
-        ),
-        vec3(0.6, 0.8, 1),
-        sqrt(max(sun_dir.z, 0.001))
-    ) * sky_tone;
+    vec3 sky_color = vec3(omw.skyColor);
 
     float sampling_factor = pow(1.25, sampling_quality);
     float lspace(float wspace) { return log(wspace) * sampling_factor; }
@@ -513,9 +501,25 @@ fragment main {
             * max(sun_dir.z, 0.0) * 3.0
             // Regulate direct lighting with max_dist to prevent it appearing on top of close objects
             * min(max_dist * (1.0 / 100000.0), 1.0);
-        vec3 fog_color = (sun_light + moon_light) * mix(sky_color, sky_tone, max(sun_dir.z, 0.3));
+        //Define the atmospheric attenuation factors for sunlight's red, green, and blue channels
+        vec3 att_factor = vec3(
+            (pow((2 / (abs(sun_dir.z) + 1)), 2) / 2),
+            (sqrt(1 / (abs(sun_dir.z) + 1)) / 2),
+            pow((1 / (abs(sun_dir.z) + 1)), 2)
+        );
+        //Interpolate between original sun color and attenuated color based on sun's proximity to the horizon
+        vec3 sun_attenuated = vec3(mix(vec3(min((sun_color.x * ((dot(dir, sun_dir) + 1) / 2) * att_factor.x), 255), min((sun_color.y * (dot(dir, sun_dir) + 1) * att_factor.y), 255), min((sun_color.z / ((dot(dir, sun_dir) + 1) * att_factor.z)),255)), sun_color, abs(sun_dir.z)));
+        //Have fog color be directionally influenced by sunlight
+        vec3 fog_color = mix(
+            vec3(omw.fogColor), 
+            (mix
+                (mix(sky_color, sun_attenuated, max(dot(dir,sun_dir), 0.0001)), 
+                (sun_attenuated + sky_color), 
+                pow(max(dot(dir,sun_dir), 0.0001),3))
+            ), 
+            (sqrt(max(dot(dir,sun_dir), 0.0001))) / 2);
 
-        vec3 fog_light = fog_color + direct_light * sun_color;
+        vec3 fog_light = fog_color + pow((direct_light * 0.05), ((sun_color.x + sun_color.y + sun_color.x) * 30 / 255)) * sun_attenuated;
 
         float dist = max_dist;
 
@@ -555,13 +559,14 @@ fragment main {
             float cloud_darken = pow(1.0 / (1.0 + fog.x), step);
             col.rgb =
                 // Attenuate light due to clouds
-                col.rgb * cloud_darken +
+                col.rgb +
                 // Re-add light that's been scattered
-                fog_light * fog.y * (1.0 - cloud_darken);
+                fog_light * fog.y * (2.0 - cloud_darken);
             */
 
             // Rayleigh scattering
-            col.rgb = mix(col.rgb, sky_color, (1.0 - 1.0 / (1.0 + step * 0.00001 * scattering_factor)) * clamp((15000 - spos.z) * 0.0001, 0.0, 1.0));
+            vec3 ambient = vec3(omw.ambientColor);
+            col.rgb = mix(col.rgb, (mix(mix(sky_color,(mix(mix(sky_color, mix(vec3(max(sun_attenuated.x, sky_color.x), max(sun_attenuated.y, sky_color.y), max(sun_attenuated.z, sky_color.z)), mix(max(ambient, sky_color), fog_color, normalize(pow((dot(sun_dir, dir) + 1), 2))), normalize(pow((dot(sun_dir, dir) + 1), 4))), (dot(dir, sun_dir) + 1)), sun_attenuated + sky_color, (sqrt(max(dot(dir, sun_dir), 0.0001)) / 2))), (dot(dir, sun_dir), + 1)), max(max(sky_color, ambient), fog_color), abs(sun_dir.z))), (1.0 - 1.0 / (1.0 + step * 0.00001 * scattering_factor * (2 + (pow((dot(dir, sun_dir), + 1), 2) )* 5))) * clamp((15000 - spos.z) * 0.0001, 0.0, 1.0));
 
             dist = new_dist;
             f -= 1;
@@ -573,7 +578,7 @@ fragment main {
     vec3 sun_light(vec3 dir) {
         const float frac = 0.003;
         vec3 sun = clamp(pow(max((dot(dir, sun_dir) - (1.0 - frac)) * (1.0 / frac), 0.0001), 10), 0, 1) * sun_color * 50;
-        vec3 sun_glare = pow(max(dot(dir, sun_dir), 0.0001), 10) * sun_color * 0.5;
+        vec3 sun_glare = pow(max(dot(dir, sun_dir), 0.0001), 10) * sun_color * 0.2;
 
         return sun + sun_glare;
     }
@@ -660,7 +665,7 @@ fragment main {
         float dyn_mist = 0.4;
         if (dynamic_mist) {
             //Calc mist based on weather state
-            float weather_mist = mix(mist_transition[omw.weatherID],mist_transition[omw.nextWeatherID],omw.weatherTransition);
+            float weather_mist = omw.fogColor.z;
             //Filter for time of day 5-8 = max mist, blending an hour each side.
             float morning_mist = 1-abs(omw.gameHour-clamp(omw.gameHour, 5 , 8));
             //Which ever is greater wins..
@@ -677,7 +682,7 @@ fragment main {
 			if (max_dist >= HORIZON * 0.9) {
 				if (replace_skybox) {
 					// Darken the sky above
-					col.rgb = sky_color * mix(vec3(0.5, 0.7, 0.9), vec3(1.0), vec3(1.0 - dir.z));
+					col.rgb = sky_color * mix(sky_color, vec3(1.0), vec3(1.0 - dir.z));
 				}
 				if (better_sun) {
 					col.rgb += sun_light(dir);


### PR DESCRIPTION
This is the version that I like quite a bit more than my first PR, both visually and in the code, but there is a pitfal I've yet to overcome: during thunderstorms, half of the game's "visual sphere" (not sure how else to call it) furthest from the location of the sun turns completely black, and comes back only when a lightning strikes.

Screenshots of it functioning normally:
![screenshot016](https://github.com/zesterer/openmw-volumetric-clouds/assets/93385001/26779cc0-8a21-4b09-8194-fd5847b25752)
![screenshot017](https://github.com/zesterer/openmw-volumetric-clouds/assets/93385001/bd8123d2-92f7-477b-9e61-76dc0415f317)
![screenshot014](https://github.com/zesterer/openmw-volumetric-clouds/assets/93385001/fc1a94de-2f1d-425f-8ceb-1520ef0f9689)
