### PR TITLE
Fix clouds not rendering at all

### DIFF
--- a/shaders/clouds.omwfx
+++ b/shaders/clouds.omwfx
@@ -327,7 +327,7 @@ fragment main {
     // Replace this function with the one below it if your GPU can't handle bitwise ops
     float hash_one(int q) {
         int n = ((M3 * q) ^ M2) * M1;
-        return float(n) * (1.0 / float(0xffffffff));
+        return float(n) * (1.0 / float(0xffffffffu));
     }
 
     float noise_2d(vec2 pos) {


### PR DESCRIPTION
No idea what happened with https://github.com/zesterer/openmw-volumetric-clouds/commit/818da0aa434b50809f30764955b3f2ddf886d04a but it removed all the letter Us, the following commit fixed it but it forgot the u at the end of the hash at line 330, which caused the clouds to stop rendering entirely, this adds it back.

closes https://github.com/zesterer/openmw-volumetric-clouds/issues/38